### PR TITLE
fix debian tag name

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,3 +1,4 @@
 [DEFAULT]
 debian-branch=master
-upstream-tag=$(version)s
+upstream-tag=%(version)s
+debian-tag=%(version)s


### PR DESCRIPTION
there was a syntax error in the upstream-tag, and the debian tag wasn't matching the existing tag layout.