### PR TITLE
Add plot grid and show bad shutdown support.

### DIFF
--- a/misc/scripts/tuptime-barchart.py
+++ b/misc/scripts/tuptime-barchart.py
@@ -9,32 +9,62 @@ import logging
 import matplotlib.pyplot as plt
 from datetime import datetime, timedelta
 
+SECONDS_DAY = 86400
+
 
 class UptimeRangeInDay:
 
     def __init__(self, btime, uptime):
         """
-        :splits: list, each element is time consumed of 2 different computer state
-            (shutdown, startup) in same day, the first state is always shutdown,
-            then startup, shutdown, startup...
+        :splits: list, each element is time consumed one of 3 different computer
+            state (shutdown, startup, bad shutdown) in same day, the first state
+            is always shutdown, then startup, bad shutdown, shutdown...
             But the time consumed on one state can be 0(boot pc at midnight, the
             first element will be 0, as the first state is shutdown)
         :date: date of this startup, if the `btime` and `offtime` of db record
             crossing midnight, it will be split to 2 parts.
         :start_point: start time of this state, changing for different states.
         :end_point: end time of this state.
+        :bad_split_idxes: index of bad shutdown state in splits.
         """
-        self.splits = []
         bdate = datetime.fromtimestamp(btime)
-        self.date = datetime(bdate.year, bdate.month, bdate.day)
-        self.start_point = (btime - self.date.timestamp()) / 86400
-        self.end_point = self.start_point + uptime / 86400
-        self.splits.append(self.start_point)
-        self.splits.append(self.end_point - self.start_point)
+
+        self._splits = []
+        self._date = datetime(bdate.year, bdate.month, bdate.day)
+        self._start_point = (btime - self._date.timestamp()) / SECONDS_DAY
+        self._end_point = self._start_point + uptime / SECONDS_DAY
+        self._splits.append(self._start_point)
+        self._splits.append(self._end_point - self._start_point)
+
+    @property
+    def splits(self):
+        return self._splits
+
+    @property
+    def date(self):
+        return self._date
+
+    @property
+    def start_point(self):
+        return self._start_point
+
+    @property
+    def end_point(self):
+        return self._end_point
+
+    @end_point.setter
+    def end_point(self, end_point):
+        self._end_point = end_point
 
     def add_split(self, split_consumed_time):
         """add time cousumed by a computer state. """
-        self.splits.append(split_consumed_time)
+        self._splits.append(split_consumed_time)
+
+    def insert_split(self, idx, value):
+        self._splits.insert(idx, value)
+
+    def __len__(self):
+        return len(self._splits)
 
 
 def get_uptime_data(arg):
@@ -46,61 +76,84 @@ def get_uptime_data(arg):
     conn.execute('select rowid as startup, * from tuptime')
     db_rows = conn.fetchall()
     db_conn.close()
-    db_rows = [dict(row) for row in db_rows[:-1]]
+    db_rows = [dict(row) for row in db_rows]
 
-    if arg.set_date:
-        tuptime_install_date = get_last_midnight_date(datetime.fromtimestamp(db_rows[0]['btime']))
-        if arg.begin_date < tuptime_install_date:
-            logging.warning(f"First tuptime entry was recorded at {tuptime_install_date:%Y-%m-%d}.")
+    tuptime_install_date = get_last_midnight_date(datetime.fromtimestamp(db_rows[0]['btime']))
+    if arg.begin_date < tuptime_install_date:
+        logging.warning(f"First tuptime entry was recorded at \
+                {tuptime_install_date:%Y-%m-%d}.")
 
-        db_date_rows = []
-        # including tuptime record of day before begin_date
-        # as last tuptime record may cross midnight
-        begin_second = int(arg.begin_date.strftime("%s")) - 86400
-        end_second = int(arg.end_date.strftime("%s"))
+    db_date_rows = []
+    # including tuptime record of day before begin_date
+    # as last tuptime record may cross midnight
+    begin_second = int(arg.begin_date.strftime("%s")) - SECONDS_DAY
+    end_second = int(arg.end_date.strftime("%s"))
 
-        for row in db_rows:
-            if begin_second <= row['btime'] < end_second:
-                db_date_rows.append(row)
+    for row in db_rows:
+        if begin_second <= row['btime'] < end_second:
+            db_date_rows.append(row)
 
-        if len(db_date_rows) == 0:
-            logging.warning("No tuptime entries in this date range.")
-            sys.exit(1)
-        return db_date_rows
-
-    return db_rows
+    if len(db_date_rows) == 0:
+        logging.warning("No tuptime entries in this date range.")
+        sys.exit(1)
+    return db_date_rows
 
 
 def get_uptime_range_each_day(db_rows, arg):
-    """Get all states for all date after `tuptime` installed."""
+    """Get all states for all date between bdate and edate.
+    Focus on urid's splits which is a sequence of time consumed on each
+    state. The previous state of a startup state must be a shotdown state
+    in splits, the next state of a strtup state must be a bad shutdown
+    state.
+    When way read a new record, we always append 3 type consumed time to
+    splits(ordered in shutdown, startup, bad shutdown).
+    """
 
     uptime_ranges = []
-    max_splits_in_day = 2
+    max_splits_in_day = 3
     bdate_prev_record = datetime.fromtimestamp(db_rows[0]['btime'])
     record_before_begin_date = True
 
     def create_or_update_uptime_range():
         """Create uptime range object and insert state start/end point to object's splits."""
 
-        nonlocal uptime_ranges, max_splits_in_day, bdate_prev_record, urid
+        nonlocal uptime_ranges, max_splits_in_day, \
+            bdate_prev_record, urid, entry_state
 
         if urid.date == bdate_prev_record:
             urid_prev_record = uptime_ranges[-1]
-            urid_prev_record.add_split(urid.start_point - urid_prev_record.end_point)
-            urid_prev_record.add_split(urid.end_point - urid.start_point)
+            urid_prev_record.add_split(urid.start_point - urid_prev_record.end_point)  # downtime
+            if entry_state == 0:  # bad shutdown record
+                urid_prev_record.add_split(0)  # uptime
+                urid_prev_record.add_split(urid.end_point - urid.start_point)  # badtime
+            else:
+                urid_prev_record.add_split(urid.end_point - urid.start_point)  # uptime
+                urid_prev_record.add_split(0)  # badtime
+            if len(urid_prev_record) > max_splits_in_day:
+                max_splits_in_day = len(urid_prev_record)
             urid_prev_record.end_point = urid.end_point
-            if len(urid_prev_record.splits) > max_splits_in_day:
-                max_splits_in_day = len(urid_prev_record.splits)
         else:
+            if entry_state == 0:
+                urid.insert_split(1, 0)  # insert zero for startup state
+            else:
+                urid.insert_split(2, 0)  # insert zero for bad shutdown state
             uptime_ranges.append(urid)
             bdate_prev_record = urid.date
 
     for db_row in db_rows:
+        if db_row['offbtime'] == -1:  # last db entry
+            db_prev_record = db_rows[-2]
+            if db_prev_record['endst'] == 1:
+                uptime_ranges[-1].add_split(db_rows[-2]['downtime'] / SECONDS_DAY)
+            break
+        entry_state = db_row['endst']
+        if entry_state == 0:  # bad shutdown
+            db_row['offbtime'] = int(db_row['offbtime'] + db_row['downtime'])
         btime = db_row['btime']
         bdate = datetime.fromtimestamp(btime)
         midnight_date = datetime(bdate.year, bdate.month, bdate.day) + timedelta(days=1)
         offbtime = db_row['offbtime']
-        if arg.set_date and record_before_begin_date:
+        if record_before_begin_date:
             if datetime.fromtimestamp(offbtime) < arg.begin_date:
                 continue
             else:
@@ -110,7 +163,7 @@ def get_uptime_range_each_day(db_rows, arg):
             if offbtime > midnight_date.timestamp():
                 urid = UptimeRangeInDay(btime, midnight_date.timestamp() - btime)
                 btime = midnight_date.timestamp()
-                if arg.set_date and urid.date == arg.begin_date - timedelta(days=1):
+                if urid.date == arg.begin_date - timedelta(days=1):
                     continue
                 create_or_update_uptime_range()
                 # break, otherwise will cross end_date
@@ -124,7 +177,7 @@ def get_uptime_range_each_day(db_rows, arg):
 
     # last urid index which ignored to add last pc state
     idx_urid = len(uptime_ranges) - 1
-    if  arg.set_date and arg.end_date < datetime.today():
+    if arg.end_date < datetime.today():
         idx_urid += 1
     # add last pc state to shutdown, if total time of splits less than 1
     for up in uptime_ranges[:idx_urid]:
@@ -132,29 +185,23 @@ def get_uptime_range_each_day(db_rows, arg):
         if abs(1 - total_time) > 1e-3:
             up.splits.append(abs(1 - total_time))
 
+    if len(uptime_ranges) == 0:
+        logging.warning("Computer is running, no other record in this date range in DB.")
+        sys.exit(1)
+
     return uptime_ranges, max_splits_in_day
 
 
 def plot_time(uptime_ranges, max_splits_in_day, arg):
     """Plot stacked bar chart."""
 
-    if arg.set_date:
-        arg.past_days = len(uptime_ranges)
-    else:
-        if arg.past_days > len(uptime_ranges):
-            arg.past_days = len(uptime_ranges)
-        uptime_ranges = uptime_ranges[-arg.past_days:]
-
-    xticks = [f"{up.date:%Y%m%d}" for up in uptime_ranges]
-
-    data = []
-    for i in range(max_splits_in_day):
-        data.append([])
-        for j in range(arg.past_days):
-            if i < len(uptime_ranges[j].splits):
-                data[i].append(uptime_ranges[j].splits[i] * 24)
-            else:
-                data[i].append(0)
+    # different day got different BAD record, statistic all index that got bad
+    # record, insert a 0 to split if that day didn't have a bad record at same
+    # split index for all indexes.
+    data = [[0] * len(uptime_ranges) for _ in range(max_splits_in_day)]
+    for data_col, urid in enumerate(uptime_ranges):
+        for data_row, split in enumerate(urid.splits):
+            data[data_row][data_col] = split * 24
 
     bottom_data = copy.deepcopy(data)
     for i in range(1, len(bottom_data)):
@@ -162,27 +209,27 @@ def plot_time(uptime_ranges, max_splits_in_day, arg):
             bottom_data[i][j] += bottom_data[i - 1][j]
 
     fig, ax = plt.subplots()
-    fig.set_size_inches(arg.fig_length, arg.fig_width)
+    fig.set_size_inches(arg.fig_width, arg.fig_height)
     ind = list(range(len(uptime_ranges)))
     width = arg.bar_width
 
     p1 = ax.bar(ind, data[0], width, color='b')
     p2 = ax.bar(ind, data[1], width, color='r', bottom=data[0])
-    for i in range(2, max_splits_in_day):
-        if i % 2 == 0:
-            region_color = 'b'
-        else:
-            region_color = 'r'
+    p3 = ax.bar(ind, data[2], width, color='k', bottom=data[1])
+    colors = {0: 'b', 1: 'r', 2: 'k'}
+    for i in range(3, max_splits_in_day):
+        region_color = colors[i % 3]
         ax.bar(ind, data[i], width, color=region_color, bottom=bottom_data[i-1])
-
 
     ax.set_yticks(list(range(0, 25, 4)))
     ax.set_yticks(list(range(0, 25, 2)), minor=True)
+    xticks = [f"{up.date:%Y%m%d}" for up in uptime_ranges]
     ax.set_xticks(ind)
+    ax.set_xticklabels(xticks)
     ax.set_title("Tuptime bar chart")
     ax.set_ylabel('Hours')
     ax.set_xlabel('Date')
-    ax.legend((p1[0], p2[0]), ('downtime', 'uptime'), loc="upper right")
+    ax.legend((p1[0], p2[0], p3[0]), ('downtime', 'uptime', 'badtime'), loc="upper right")
     ax.grid(which='minor', axis='y', linestyle=(0, (3, 10, 1, 10)),
             linewidth=arg.line_width, alpha=arg.grid_alpha)
     plt.show()
@@ -213,30 +260,6 @@ def get_arguments():
         metavar='FILE'
     )
     parser.add_argument(
-        '-l', '--flength',
-        dest='fig_length',
-        default=12,
-        action='store',
-        help='figure length',
-        type=int
-    )
-    parser.add_argument(
-        '-w', '--fwidth',
-        dest='fig_width',
-        default=10,
-        action='store',
-        help='figure width',
-        type=int
-    )
-    parser.add_argument(
-        '--bwidth',
-        dest='bar_width',
-        default=.5,
-        action='store',
-        help='The width of the bars (default is 0.5).',
-        type=float
-    )
-    parser.add_argument(
         '-b', '--bdate',
         dest='begin_date',
         action='store',
@@ -247,7 +270,7 @@ def get_arguments():
         '-e', '--edate',
         dest='end_date',
         action='store',
-        help='end date to plot, format:Y-m-d. If bdate has been set, default edate is today.',
+        help='end date to plot, format:Y-m-d. Default edate is today.',
         type=str
     )
     parser.add_argument(
@@ -255,8 +278,32 @@ def get_arguments():
         dest='past_days',
         default=7,
         action='store',
-        help='past days to plot, will be ignored if set bdate (default is 7).',
+        help='past days before edate to plot, will be ignored if set bdate (default is 7).',
         type=int
+    )
+    parser.add_argument(
+        '--fwidth',
+        dest='fig_width',
+        default=10,
+        action='store',
+        help='figure width.',
+        type=int
+    )
+    parser.add_argument(
+        '--fheight',
+        dest='fig_height',
+        default=12,
+        action='store',
+        help='figure height.',
+        type=int
+    )
+    parser.add_argument(
+        '-w', '--bwidth',
+        dest='bar_width',
+        default=.5,
+        action='store',
+        help='The width of the bars (default is 0.5).',
+        type=float
     )
     parser.add_argument(
         '--lwidth',
@@ -276,23 +323,23 @@ def get_arguments():
     )
 
     arg = parser.parse_args()
+
+    if arg.end_date:
+        arg.end_date = datetime.strptime(arg.end_date, "%Y-%m-%d") + timedelta(days=1)
+        if arg.end_date > datetime.today() + timedelta(days=1):
+            logging.error("end_date can't large than today.")
+            sys.exit(-1)
+    else:
+        arg.end_date = get_last_midnight_date(datetime.today()) + timedelta(days=1)
+
     if arg.begin_date:
         arg.begin_date = datetime.strptime(arg.begin_date, "%Y-%m-%d")
-
-        if arg.end_date:
-            arg.end_date = datetime.strptime(arg.end_date, "%Y-%m-%d") + timedelta(days=1)
-            if arg.end_date > datetime.today() + timedelta(days=1):
-                logging.error("end_date can't large than today.")
-                sys.exit(-1)
-        else:
-            arg.end_date = get_last_midnight_date(datetime.today()) + timedelta(days=1)
-
-        if arg.begin_date >= arg.end_date:
-            logging.error("begin_date can't large than end_date.")
-            sys.exit(-1)
-        arg.set_date = True
     else:
-        arg.set_date = False
+        arg.begin_date = arg.end_date - timedelta(days=arg.past_days)
+
+    if arg.begin_date >= arg.end_date:
+        logging.error("begin_date must be earlier than end_date.")
+        sys.exit(-1)
 
     return arg
 

--- a/misc/scripts/tuptime-barchart.py
+++ b/misc/scripts/tuptime-barchart.py
@@ -14,12 +14,12 @@ class UptimeRangeInDay:
 
     def __init__(self, btime, uptime):
         """
-        :splits: list, each element is time consumed of 2 different computer state
+        :splits: list, each element is time spent of 2 different computer state
             (shutdown, startup) in same day, the first state is always shutdown,
             then startup, shutdown, startup...
-            But the time consumed on one state can be 0(boot pc at midnight, the
+            But the time spent on one state can be 0(boot pc at midnight, the
             first element will be 0, as the first state is shutdown)
-        :date: date of this startup, if the `btime` and `offtime` of db record
+        :day: date of this startup, if the `btime` and `offtime` of db record
             crossing midnight, it will be split to 2 parts.
         :start_point: start time of this state, changing for different states.
         :end_point: end time of this state.
@@ -31,10 +31,6 @@ class UptimeRangeInDay:
         self.end_point = self.start_point + uptime / 86400
         self.splits.append(self.start_point)
         self.splits.append(self.end_point - self.start_point)
-
-    def add_split(self, split_consumed_time):
-        """add time cousumed by a computer state. """
-        self.splits.append(split_consumed_time)
 
 
 def get_uptime_data(arg):
@@ -86,8 +82,8 @@ def get_uptime_range_each_day(db_rows, arg):
 
         if urid.date == bdate_prev_record:
             urid_prev_record = uptime_ranges[-1]
-            urid_prev_record.add_split(urid.start_point - urid_prev_record.end_point)
-            urid_prev_record.add_split(urid.end_point - urid.start_point)
+            urid_prev_record.splits.append(urid.start_point - urid_prev_record.end_point)
+            urid_prev_record.splits.append(urid.end_point - urid.start_point)
             urid_prev_record.end_point = urid.end_point
             if len(urid_prev_record.splits) > max_splits_in_day:
                 max_splits_in_day = len(urid_prev_record.splits)
@@ -179,7 +175,7 @@ def plot_time(uptime_ranges, max_splits_in_day, arg):
     plt.title("Tuptime bar chart")
     plt.ylabel('Hours')
     plt.xlabel('Date')
-    plt.legend((p1[0], p2[0]), ('downtime', 'uptime'), loc="upper right")
+    plt.legend((p1[0], p2[0]), ('downtime', 'uptime'))
     plt.show()
 
 

--- a/misc/scripts/tuptime-barchart.py
+++ b/misc/scripts/tuptime-barchart.py
@@ -161,25 +161,30 @@ def plot_time(uptime_ranges, max_splits_in_day, arg):
         for j in range(len(bottom_data[0])):
             bottom_data[i][j] += bottom_data[i - 1][j]
 
-    plt.figure(figsize=(arg.fig_length, arg.fig_width))
+    fig, ax = plt.subplots()
+    fig.set_size_inches(arg.fig_length, arg.fig_width)
     ind = list(range(len(uptime_ranges)))
     width = arg.bar_width
 
-    p1 = plt.bar(ind, data[0], width, color='b')
-    p2 = plt.bar(ind, data[1], width, color='r', bottom=data[0])
+    p1 = ax.bar(ind, data[0], width, color='b')
+    p2 = ax.bar(ind, data[1], width, color='r', bottom=data[0])
     for i in range(2, max_splits_in_day):
         if i % 2 == 0:
             region_color = 'b'
         else:
             region_color = 'r'
-        plt.bar(ind, data[i], width, color=region_color, bottom=bottom_data[i-1])
+        ax.bar(ind, data[i], width, color=region_color, bottom=bottom_data[i-1])
 
-    plt.xticks(ind, xticks)
-    plt.yticks(list(range(0, 25, 2)))
-    plt.title("Tuptime bar chart")
-    plt.ylabel('Hours')
-    plt.xlabel('Date')
-    plt.legend((p1[0], p2[0]), ('downtime', 'uptime'), loc="upper right")
+
+    ax.set_yticks(list(range(0, 25, 4)))
+    ax.set_yticks(list(range(0, 25, 2)), minor=True)
+    ax.set_xticks(ind)
+    ax.set_title("Tuptime bar chart")
+    ax.set_ylabel('Hours')
+    ax.set_xlabel('Date')
+    ax.legend((p1[0], p2[0]), ('downtime', 'uptime'), loc="upper right")
+    ax.grid(which='minor', axis='y', linestyle=(0, (3, 10, 1, 10)),
+            linewidth=arg.line_width, alpha=arg.grid_alpha)
     plt.show()
 
 
@@ -189,7 +194,16 @@ def get_last_midnight_date(date):
 
 def get_arguments():
     DB_FILE = '/var/lib/tuptime/tuptime.db'
-    parser = argparse.ArgumentParser()
+
+    class CustomHelpFormatter(argparse.HelpFormatter):
+        def _format_action_invocation(self, action):
+            if not action.option_strings or action.nargs == 0:
+                return super()._format_action_invocation(action)
+            default = self._get_default_metavar_for_optional(action)
+            args_string = self._format_args(action, default)
+            return ', '.join(action.option_strings) + ' ' + args_string
+
+    parser = argparse.ArgumentParser(formatter_class=lambda prog: CustomHelpFormatter(prog))
     parser.add_argument(
         '-f', '--filedb',
         dest='db_file',
@@ -215,7 +229,7 @@ def get_arguments():
         type=int
     )
     parser.add_argument(
-        '-bw', '--bwidth',
+        '--bwidth',
         dest='bar_width',
         default=.5,
         action='store',
@@ -243,6 +257,22 @@ def get_arguments():
         action='store',
         help='past days to plot, will be ignored if set bdate (default is 7).',
         type=int
+    )
+    parser.add_argument(
+        '--lwidth',
+        dest='line_width',
+        default=1,
+        action='store',
+        help='line width of figure grid (default is 1).',
+        type=float
+    )
+    parser.add_argument(
+        '-a', '--galpha',
+        dest='grid_alpha',
+        default=.0,
+        action='store',
+        help='alpha value of figure grid (default is 0).',
+        type=float
     )
 
     arg = parser.parse_args()

--- a/misc/scripts/tuptime-barchart.py
+++ b/misc/scripts/tuptime-barchart.py
@@ -14,12 +14,12 @@ class UptimeRangeInDay:
 
     def __init__(self, btime, uptime):
         """
-        :splits: list, each element is time spent of 2 different computer state
+        :splits: list, each element is time consumed of 2 different computer state
             (shutdown, startup) in same day, the first state is always shutdown,
             then startup, shutdown, startup...
-            But the time spent on one state can be 0(boot pc at midnight, the
+            But the time consumed on one state can be 0(boot pc at midnight, the
             first element will be 0, as the first state is shutdown)
-        :day: date of this startup, if the `btime` and `offtime` of db record
+        :date: date of this startup, if the `btime` and `offtime` of db record
             crossing midnight, it will be split to 2 parts.
         :start_point: start time of this state, changing for different states.
         :end_point: end time of this state.
@@ -31,6 +31,10 @@ class UptimeRangeInDay:
         self.end_point = self.start_point + uptime / 86400
         self.splits.append(self.start_point)
         self.splits.append(self.end_point - self.start_point)
+
+    def add_split(self, split_consumed_time):
+        """add time cousumed by a computer state. """
+        self.splits.append(split_consumed_time)
 
 
 def get_uptime_data(arg):
@@ -82,8 +86,8 @@ def get_uptime_range_each_day(db_rows, arg):
 
         if urid.date == bdate_prev_record:
             urid_prev_record = uptime_ranges[-1]
-            urid_prev_record.splits.append(urid.start_point - urid_prev_record.end_point)
-            urid_prev_record.splits.append(urid.end_point - urid.start_point)
+            urid_prev_record.add_split(urid.start_point - urid_prev_record.end_point)
+            urid_prev_record.add_split(urid.end_point - urid.start_point)
             urid_prev_record.end_point = urid.end_point
             if len(urid_prev_record.splits) > max_splits_in_day:
                 max_splits_in_day = len(urid_prev_record.splits)
@@ -175,7 +179,7 @@ def plot_time(uptime_ranges, max_splits_in_day, arg):
     plt.title("Tuptime bar chart")
     plt.ylabel('Hours')
     plt.xlabel('Date')
-    plt.legend((p1[0], p2[0]), ('downtime', 'uptime'))
+    plt.legend((p1[0], p2[0]), ('downtime', 'uptime'), loc="upper right")
     plt.show()
 
 


### PR DESCRIPTION
Hi @rfrail3 I made an update for the `plot bar chart` script.

1. support plot grid, it will be helpful when you what know the start time and end time of a bar split.
2. plot badtime state if an database entry's `endst` is BAD.

```
(nn) hmank ~/c/G/tuptime dev » tup -a 1 --lwidth 1.5
```

![Figure_1](https://user-images.githubusercontent.com/9500049/55238979-b485e780-5270-11e9-8daa-e85ef5e5cfb2.png)

If we got an `tuptime` entry like this:

```
{'startup': 34,
  'btime': 1553735469,
  'uptime': 4.74,
  'offbtime': 1553735474,
  'endst': 0,
  'downtime': 9497.26,
  'kernel': 'Linux-4.20.17-1-MANJARO-x86_64-with-arch-Manjaro-Linux'},
```

All time consumed by `startup` and `shutdown` state will be added and turn to `badtime` meas bad shutdown time.

---

usage:

```
(nn) hmank ~/c/G/tuptime dev » tup -h               
usage: tuptime-barchart.py [-h] [-f FILE] [-b BEGIN_DATE] [-e END_DATE]
                           [-p PAST_DAYS] [--fwidth FIG_WIDTH]
                           [--fheight FIG_HEIGHT] [-w BAR_WIDTH]
                           [--lwidth LINE_WIDTH] [-a GRID_ALPHA]

optional arguments:
  -h, --help            show this help message and exit
  -f, --filedb FILE     database file
  -b, --bdate BEGIN_DATE
                        begin date to plot, format:Y-m-d.
  -e, --edate END_DATE  end date to plot, format:Y-m-d. Default edate is
                        today.
  -p, --pastdays PAST_DAYS
                        past days before edate to plot, will be ignored if set
                        bdate (default is 7).
  --fwidth FIG_WIDTH    figure width.
  --fheight FIG_HEIGHT  figure height.
  -w, --bwidth BAR_WIDTH
                        The width of the bars (default is 0.5).
  --lwidth LINE_WIDTH   line width of figure grid (default is 1).
  -a, --galpha GRID_ALPHA
                        alpha value of figure grid (default is 0).
```