### PR TITLE
Add AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Or swich to -l | --list option:
 * Ubuntu: https://packages.ubuntu.com/tuptime
 * Fedora, EPEL: https://src.fedoraproject.org/rpms/tuptime
 * FreeBSD: https://www.freshports.org/sysutils/tuptime
+* Arch: https://aur.archlinux.org/packages/tuptime
 
 
 #### By one-liner script


### PR DESCRIPTION
I'm using tuptime on my Arch and you can install it from the AUR.

I have only edited the Readme to add the link to the AUR.